### PR TITLE
Added TypeCase and matchAsync

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ class OtherSampleClass {
 class UnmatchedClass {
 }
 
+export interface IQux { q: number; }
+
+export function isQux(obj: any): obj is IQux {
+    return !!obj && typeof obj === "object" && "q" in obj && typeof obj.q === "number";
+}
+
 
 function testMatch(a: any): number {
   return match(a,
@@ -34,6 +40,8 @@ function testMatch(a: any): number {
       Case(SampleClass, (sampleClass) => sampleClass.myData),
       // matches if argument is of type OtherSampleClass
       Case(OtherSampleClass, (otherSampleClass) => otherSampleClass.myOtherData),
+      // matches if a is an object with a number property named "q"
+      TypeCase(isQux, (qux) => qux.q),
       // matches if argument === 23
       Case(23, (n) => n + 1),
       // matches if argument === "asdf"
@@ -54,6 +62,9 @@ assert.equal(testMatch(sampleClass), sampleClass.myData);
 
 const otherSampleClass = new OtherSampleClass(2);
 assert.equal(testMatch(otherSampleClass), otherSampleClass.myOtherData);
+
+ const qux = { q: 3 };
+assert.equal(testMatch(qux), qux.q);
 
 assert.equal(testMatch(23), 23 + 1);
 

--- a/package.json
+++ b/package.json
@@ -12,9 +12,11 @@
   },
   "devDependencies": {
     "@types/chai": "^3.5.0",
+    "@types/es6-promise": "^0.0.32",
     "@types/mocha": "^2.2.40",
     "@types/source-map-support": "^0.2.28",
     "chai": "^3.5.0",
+    "es6-promise": "^4.1.0",
     "mocha": "^3.2.0",
     "mocha-junit-reporter": "^1.13.0",
     "source-map-support": "^0.4.14",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export interface IType<T> { new(...args: any[]): T; }
+export interface IType<T> { new (...args: any[]): T; }
 
 export interface ICaseResult<R> {
     success: boolean;
@@ -34,6 +34,17 @@ export function Case<R>(type: any, project: (t: any) => R): CaseFn<R> {
             typeof type === "boolean" && type ||
             typeof type === typeof a && type === a
         );
+
+        const result = success && project(a);
+        return { success, result };
+    };
+}
+
+export type TypeGuard<T> = (x: any) => x is T;
+export function TypeCase<T, R>(type: TypeGuard<T>, project: (t: T) => R): CaseFn<R> {
+    return (a) => {
+        const success = !!a && (typeof type === "function" && !!type(a));
+
         const result = success && project(a);
         return { success, result };
     };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
+import "es6-promise";
+
 export interface IType<T> { new (...args: any[]): T; }
 
 export interface ICaseResult<R> {
@@ -62,4 +64,19 @@ export function match<A, R>(a: A, ...cases: Array<CaseFn<R>>): R {
         }
     }
     return undefined;
+}
+
+// Will wrap all return values in a Promise, so the whole matcher can be safely handled as a promise
+export function matchAsync<A, R>(a: A, ...cases: Array<CaseFn<Promise<R> | R>>): Promise<R> {
+    for (const c of cases) {
+        const r = c(a);
+        if (r.success) {
+            return Promise.resolve(r.result);
+        }
+    }
+    return undefined;
+}
+
+function isPromise(obj: any) {
+    return !!obj.then && typeof obj.then === "function";
 }

--- a/test/OtherSampleClass.ts
+++ b/test/OtherSampleClass.ts
@@ -1,3 +1,3 @@
 export default class OtherSampleClass {
-    constructor(public myOtherData: number) {}
+    constructor(public myOtherData: number) { }
 }

--- a/test/SampleClass.ts
+++ b/test/SampleClass.ts
@@ -1,3 +1,3 @@
 export default class SampleClass {
-    constructor(public myData: number) {}
+    constructor(public myData: number) { }
 }

--- a/test/test.ts
+++ b/test/test.ts
@@ -1,7 +1,9 @@
 import { assert } from "chai";
+import { IQux, isQux } from "./typeGuardSample";
+
 import * as sourceMapSupport from "source-map-support";
 
-import { Case, DefaultCase, match, NumberCase, StringCase } from "../src/index";
+import { Case, DefaultCase, match, NumberCase, StringCase, TypeCase } from "../src/index";
 import OtherSampleClass from "./OtherSampleClass";
 import SampleClass from "./SampleClass";
 import UnmatchedClass from "./UnmatchedClass";
@@ -9,11 +11,13 @@ import UnmatchedClass from "./UnmatchedClass";
 sourceMapSupport.install();
 
 describe("match", () => {
+
     it("calls the right function depending on its type", () => {
         function testMatch(a: any): number {
             return match(a,
                 Case(SampleClass, (sampleClass) => sampleClass.myData),
                 Case(OtherSampleClass, (otherSampleClass) => otherSampleClass.myOtherData),
+                TypeCase(isQux, (qux) => qux.q),
                 Case(23, (n) => n + 1),
                 Case("asdf", (s) => s.length),
                 Case(a + 1 === 2, () => 2),
@@ -28,6 +32,9 @@ describe("match", () => {
 
         const otherSampleClass = new OtherSampleClass(2);
         assert.equal(testMatch(otherSampleClass), otherSampleClass.myOtherData);
+
+        const qux = { q: 3 };
+        assert.equal(testMatch(qux), qux.q);
 
         assert.equal(testMatch(23), 23 + 1);
 

--- a/test/test.ts
+++ b/test/test.ts
@@ -3,7 +3,7 @@ import { IQux, isQux } from "./typeGuardSample";
 
 import * as sourceMapSupport from "source-map-support";
 
-import { Case, DefaultCase, match, NumberCase, StringCase, TypeCase } from "../src/index";
+import { Case, DefaultCase, match, matchAsync, NumberCase, StringCase, TypeCase } from "../src/index";
 import OtherSampleClass from "./OtherSampleClass";
 import SampleClass from "./SampleClass";
 import UnmatchedClass from "./UnmatchedClass";
@@ -47,5 +47,48 @@ describe("match", () => {
         assert.equal(testMatch("arbitrarystring"), "arbitrarystring".length + 1);
 
         assert.equal(testMatch(new UnmatchedClass()), -1);
+    });
+});
+
+describe("matchAsync", () => {
+
+    it("should safely handle promises in a match chain", async () => {
+        function testMatch(a: any): Promise<number> {
+            return matchAsync(a,
+                Case(SampleClass, (sampleClass) => sampleClass.myData),
+                // Test for an async Value
+                Case(OtherSampleClass, (otherSampleClass) => Promise.resolve(otherSampleClass.myOtherData)),
+                TypeCase(isQux, (qux) => qux.q),
+                Case(23, (n) => n + 1),
+                Case("asdf", (s) => s.length),
+                Case(a + 1 === 2, () => 2),
+                NumberCase((n) => n + 5),
+                StringCase((s) => s.length + 1),
+                DefaultCase(-1),
+            );
+        }
+
+        const sampleClass = new SampleClass(1);
+        assert.equal(await testMatch(sampleClass), sampleClass.myData);
+
+        const otherSampleClass = new OtherSampleClass(2);
+        assert.equal(await testMatch(otherSampleClass), otherSampleClass.myOtherData);
+
+        const qux = { q: 3 };
+        assert.equal(await testMatch(qux), qux.q);
+
+        assert.equal(await testMatch(23), 23 + 1);
+
+        assert.equal(await testMatch("asdf"), "asdf".length);
+
+        assert.equal(await testMatch(true), 2);
+
+        assert.equal(await testMatch(24), 24 + 5);
+
+        assert.equal(await testMatch("arbitrarystring"), "arbitrarystring".length + 1);
+
+        assert.equal(await testMatch(new UnmatchedClass()), -1);
+
+        return;
     });
 });

--- a/test/typeGuardSample.ts
+++ b/test/typeGuardSample.ts
@@ -1,0 +1,5 @@
+export interface IQux { q: number; }
+
+export function isQux(obj: any): obj is IQux {
+    return !!obj && typeof obj === "object" && "q" in obj && typeof obj.q === "number";
+}

--- a/tslint.json
+++ b/tslint.json
@@ -1,5 +1,10 @@
 {
-    "extends": [
-      "tslint:latest"
+  "extends": [
+    "tslint:latest"
+  ],
+  "rules": {
+    "no-console": [
+      false
     ]
+  }
 }

--- a/tslint.json
+++ b/tslint.json
@@ -1,10 +1,5 @@
 {
   "extends": [
     "tslint:latest"
-  ],
-  "rules": {
-    "no-console": [
-      false
-    ]
-  }
+  ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6,6 +6,10 @@
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/@types/chai/-/chai-3.5.0.tgz#45e2dc2af9a5727be846af6e61d08ffc45d5b2ca"
 
+"@types/es6-promise@^0.0.32":
+  version "0.0.32"
+  resolved "https://registry.yarnpkg.com/@types/es6-promise/-/es6-promise-0.0.32.tgz#3bcf44fb1e429f3df76188c8c6d874463ba371fd"
+
 "@types/mocha@^2.2.40":
   version "2.2.40"
   resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-2.2.40.tgz#9811dd800ece544cd84b5b859917bf584a150c4c"
@@ -114,6 +118,10 @@ diff@1.4.0:
 diff@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.2.0.tgz#c9ce393a4b7cbd0b058a725c93df299027868ff9"
+
+es6-promise@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.1.0.tgz#dda03ca8f9f89bc597e689842929de7ba8cebdf0"
 
 escape-string-regexp@1.0.5, escape-string-regexp@^1.0.2:
   version "1.0.5"


### PR DESCRIPTION
As suggested by @rob3c in Microsoft/TypeScript#165 I added a TypeCase option for matching on interfaces. 
Consolidating it in the original Case  function easily clashes with the Class check, since there's no simple way to differentiate between a class function and a typeguard function. 

(that's one of the reasons why the unit tests previously failed)

I Also added matchAsync which makes it possible to handle cases with async returns (by wrapping all cases in Promise.resolve so matchAsync can be safely awaited).

@jroitgrund if you prefer to name it differently or if you can see a way to consolidate it with the original case function please let me know.
 I should have moved matchAsync into a seperate branch and requested a separate pull request. So let me know if you wan't me to gut it up and request it again